### PR TITLE
ci: update package registry before building documentation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,9 @@ jobs:
 
   - job: documentation
     steps:
+      - script: sudo apt-get update
+        displayName: Update package registry
+
       - script: sudo apt-get install ninja-build xmlto texinfo source-highlight libxml2-utils xsltproc fop -y
         displayName: Install dependencies
 


### PR DESCRIPTION
Apparently this is caused by:

https://developercommunity.visualstudio.com/content/problem/907292/microsoft-hosted-agent-ubuntu-1804-is-not-up-to-da.html